### PR TITLE
Added CACHE_DIR_* directives for additional mounts

### DIFF
--- a/Zestfile.example
+++ b/Zestfile.example
@@ -43,6 +43,12 @@ VERSION=
 # Will be mounted at $MOUNT_DIR/<service-name>
 MOUNT_DIR=
 
+# CACHE_DIR_SRC
+# CACHE_DIR_DST
+# Additional mount for cached code, modules, or assets
+CACHE_DIR_SRC=
+CACHE_DIR_DST=
+
 # PreBuild()
 # The script to be executed outside of the build container (local machine)
 # before the build step

--- a/zest
+++ b/zest
@@ -169,7 +169,14 @@ _zest_build() {
 
 	# Build in the container
 	_info "Building service $SERVICE in $BUILD_CONTAINER"
-	docker run --rm -v $(pwd):$MOUNT_DIR/$SERVICE -w $MOUNT_DIR/$SERVICE -v $ZESTER_PATH:/usr/bin/zester $BUILD_CONTAINER zester build --name $SERVICE
+
+	# Check for cache dir
+	if [[ ! -z $CACHE_DIR_SRC && ! -z $CACHE_DIR_DST ]]; then
+		_debug "Including cache directory $CACHE_DIR_SRC => $CACHE_DIR_DST"
+		docker run --rm -v $(pwd):$MOUNT_DIR/$SERVICE -w $MOUNT_DIR/$SERVICE -v $ZESTER_PATH:/usr/bin/zester:ro -v $CACHE_DIR_SRC:$CACHE_DIR_DST $BUILD_CONTAINER zester build --name $SERVICE
+	else
+		docker run --rm -v $(pwd):$MOUNT_DIR/$SERVICE -w $MOUNT_DIR/$SERVICE -v $ZESTER_PATH:/usr/bin/zester:ro $BUILD_CONTAINER zester build --name $SERVICE
+	fi
 
 	if [[ $? -ne 0 ]]; then
 		_fatal "Build failed"


### PR DESCRIPTION
So with this method, we don't need the `.dockerignore` anymore, correct?
