### PR TITLE
-s/--service flag on Zest Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Zest is to assist with docker-driven workflow in both a local dev environment an
 
 ## Requirements
 Zest requires `zest`, `_zester`, `docker`, and `docker-compose` (v1.12 or newer, see below)
-to be installed in your PATH. The Docker daemon must be running. 
+to be installed in your PATH. The Docker daemon must be running.
 
 You must have docker-compose >= 1.12 installed. It is included in Docker for Mac edge since 17.04.
-The latest version of Docker for Mac stable (17.03) does not yet bundle this version. 
-Either use https://github.com/axiomzen/zest/commit/d6afabaa7100b56b326abab55fa11c4e4b71c4b1 
-or [update docker-compose](https://docs.docker.com/compose/install/). 
+The latest version of Docker for Mac stable (17.03) does not yet bundle this version.
+Either use https://github.com/axiomzen/zest/commit/d6afabaa7100b56b326abab55fa11c4e4b71c4b1
+or [update docker-compose](https://docs.docker.com/compose/install/).
 
 ## Installation
 To install things system wide use `sudo make install`, which will attempt to copy the binaries and relevant configs into `/usr/local` as well as the users `~/.zest` directories.
@@ -50,7 +50,7 @@ Command | Result
 --------|--------
 init-project | Creates the prerequisite files for the current directory to be a zestable project
 integrate | Run integration tests on a project
-run | Start the environment with docker-compose
+run | Start the environment with docker-compose. Use flag `-s` or `--service SERVICENAME` to run an individual service along with its dependencies
 stop | clean up the docker-compose environment
 all | build, test, bundle all folders in the pwd that are services, then integrate
 

--- a/example/Peelfile
+++ b/example/Peelfile
@@ -3,3 +3,4 @@ integrate: integrater
 project: example
 compose: docker-compose.yml
 compose-integrate: docker-compose.integrate.yml
+compose-development: docker-compose.dev.yml

--- a/zest
+++ b/zest
@@ -154,11 +154,11 @@ _zest_run() {
 		_fatal "Not a zest project"
 	fi
 
-	RUN_SERVICE=`grep -E -i "^run: " Peelfile | awk '{print $2}'`
+    RUN_SERVICE="${SERVICE_ARG:-`grep -E -i "^run: " Peelfile | awk '{print $2}'`}"
 
 	if [[ "$RUN_SERVICE" == "" ]]; then
-		_fatal "run: not specified in Peelfile"
-	fi
+		_fatal "run: not specified in Peelfile nor in --service"
+    fi
 
 	_info "Running service $RUN_SERVICE"
 
@@ -174,7 +174,7 @@ _zest_stop() {
 	fi
 
 	_info "Stopping project"
-	
+
 	docker-compose -f $COMPOSE_FILE $DOCKER_VERBOSE down --rmi local
 }
 
@@ -437,7 +437,7 @@ _zest_test() {
 		SERVICE_NAME=$SERVICE
 		_debug "SERVICE_NAME not set, using $SERVICE"
 	fi
-	
+
 	# Build in the container
 	_info "Testing service $SERVICE in $TEST_CONTAINER"
 	docker run --rm -v $(pwd):$MOUNT_DIR/$SERVICE -w $MOUNT_DIR/$SERVICE -v $ZESTER_PATH:/usr/bin/zester:ro $(_zest_cache_volumes) $TEST_CONTAINER zester test --name $SERVICE_NAME
@@ -716,6 +716,7 @@ DEFAULT_VERSION=true
 BUILD_ARGS=
 DOCKER_VERBOSE=
 GO_VERBOSE=
+SERVICE_ARG=
 
 while [[ $# -gt 0 ]]; do
 	case $1 in
@@ -730,6 +731,10 @@ while [[ $# -gt 0 ]]; do
 		-b|--build-args)
 			shift && BUILD_ARGS="$1"
 			;;
+		-s|--service)
+			shift && SERVICE_ARG="$1"
+			;;
+
 	esac
 	shift
 done


### PR DESCRIPTION
Zest run can now run individual services instead of running the main
peelfile `run` argument.