### PR TITLE
Zest Build/Test/Bundle --service flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Zest is to assist with docker-driven workflow in both a local dev environment an
 
 ## Requirements
 Zest requires `zest`, `_zester`, `docker`, and `docker-compose` (v1.12 or newer, see below)
-to be installed in your PATH. The Docker daemon must be running. 
+to be installed in your PATH. The Docker daemon must be running.
 
 You must have docker-compose >= 1.12 installed. It is included in Docker for Mac edge since 17.04.
-The latest version of Docker for Mac stable (17.03) does not yet bundle this version. 
-Either use https://github.com/axiomzen/zest/commit/d6afabaa7100b56b326abab55fa11c4e4b71c4b1 
-or [update docker-compose](https://docs.docker.com/compose/install/). 
+The latest version of Docker for Mac stable (17.03) does not yet bundle this version.
+Either use https://github.com/axiomzen/zest/commit/d6afabaa7100b56b326abab55fa11c4e4b71c4b1
+or [update docker-compose](https://docs.docker.com/compose/install/).
 
 ## Installation
 To install things system wide use `sudo make install`, which will attempt to copy the binaries and relevant configs into `/usr/local` as well as the users `~/.zest` directories.
@@ -50,7 +50,7 @@ Command | Result
 --------|--------
 init-project | Creates the prerequisite files for the current directory to be a zestable project
 integrate | Run integration tests on a project
-run | Start the environment with docker-compose
+run | Start the environment with docker-compose. Use flag `-s` or `--service SERVICENAME` to run an individual service along with its dependencies
 stop | clean up the docker-compose environment
 all | build, test, bundle all folders in the pwd that are services, then integrate
 

--- a/example/Peelfile
+++ b/example/Peelfile
@@ -3,3 +3,4 @@ integrate: integrater
 project: example
 compose: docker-compose.yml
 compose-integrate: docker-compose.integrate.yml
+compose-development: docker-compose.dev.yml

--- a/zest
+++ b/zest
@@ -210,12 +210,18 @@ _zest_cache_volumes() {
 
 _zest_build() {
 
-	# Get the service name (folder name)
-	SERVICE=$(basename `pwd`)
+    SERVICE="${SERVICE_ARG:-$(basename `pwd`)}"
 
 	# First ensure we're a service
-	_debug "Checking service"
-	if ! _zest_is_service . ; then
+	_debug "Checking service ${SERVICE}"
+
+    SERVICEPATH=$(find . -type d -maxdepth 2 | grep ${SERVICE} | head -n 1)
+    if [[ "$SERVICEPATH" == "" ]]; then
+	 _debug "Service path is empty, setting to current path"
+       SERVICEPATH="."
+    fi
+
+	if ! _zest_is_service $SERVICEPATH ; then
 		_fatal "$SERVICE is not a service"
 	fi
 
@@ -627,7 +633,7 @@ _zest_all() {
 		_debug "Checking $dir"
 		if _zest_is_service $dir; then
 			_info "Zesting $dir"
-			bash -c "cd $dir; $ABSOLUTE_PATH build $GO_VERBOSE && $ABSOLUTE_PATH test $GO_VERBOSE && $ABSOLUTE_PATH bundle $GO_VERBOSE" || _fatal "Zest all failed"
+			bash -c "$ABSOLUTE_PATH build -s $dir $GO_VERBOSE && $ABSOLUTE_PATH test $GO_VERBOSE && $ABSOLUTE_PATH bundle $GO_VERBOSE" || _fatal "Zest all failed"
 		fi
 	done
 
@@ -731,7 +737,7 @@ while [[ $# -gt 0 ]]; do
 		-b|--build-args)
 			shift && BUILD_ARGS="$1"
 			;;
-		-s|--service)
+		-s|--service|--service-path)
 			shift && SERVICE_ARG="$1"
 			;;
 

--- a/zest
+++ b/zest
@@ -154,11 +154,11 @@ _zest_run() {
 		_fatal "Not a zest project"
 	fi
 
-	RUN_SERVICE=`grep -E -i "^run: " Peelfile | awk '{print $2}'`
+    RUN_SERVICE="${SERVICE_ARG:-`grep -E -i "^run: " Peelfile | awk '{print $2}'`}"
 
 	if [[ "$RUN_SERVICE" == "" ]]; then
-		_fatal "run: not specified in Peelfile"
-	fi
+		_fatal "run: not specified in Peelfile nor in --service"
+    fi
 
 	_info "Running service $RUN_SERVICE"
 
@@ -174,7 +174,7 @@ _zest_stop() {
 	fi
 
 	_info "Stopping project"
-	
+
 	docker-compose -f $COMPOSE_FILE $DOCKER_VERBOSE down --rmi local
 }
 
@@ -437,7 +437,7 @@ _zest_test() {
 		SERVICE_NAME=$SERVICE
 		_debug "SERVICE_NAME not set, using $SERVICE"
 	fi
-	
+
 	# Build in the container
 	_info "Testing service $SERVICE in $TEST_CONTAINER"
 	docker run --rm -v $(pwd):$MOUNT_DIR/$SERVICE -w $MOUNT_DIR/$SERVICE -v $ZESTER_PATH:/usr/bin/zester:ro $(_zest_cache_volumes) $TEST_CONTAINER zester test --name $SERVICE_NAME
@@ -716,6 +716,7 @@ DEFAULT_VERSION=true
 BUILD_ARGS=
 DOCKER_VERBOSE=
 GO_VERBOSE=
+SERVICE_ARG=
 
 while [[ $# -gt 0 ]]; do
 	case $1 in
@@ -730,6 +731,10 @@ while [[ $# -gt 0 ]]; do
 		-b|--build-args)
 			shift && BUILD_ARGS="$1"
 			;;
+		-s|--service)
+			shift && SERVICE_ARG="$1"
+			;;
+
 	esac
 	shift
 done

--- a/zest
+++ b/zest
@@ -82,7 +82,7 @@ _zest_is_service() {
 	fi
 
 	# load the Zestfile
-	_debug "Loading Zestfile"
+	_debug "Loading Zestfile at ${1}/Zestfile"
 	source $1/Zestfile
 
 	# check for docker file override
@@ -185,7 +185,7 @@ _zest_cache_volumes() {
 
 	# handle legacy variables
 	if [[ ! -z $CACHE_DIR_SRC && ! -z $CACHE_DIR_DST ]]; then
-		# _debug "Including cache directory $CACHE_DIR_SRC => $CACHE_DIR_DST"
+		 #_debug "Including cache directory $CACHE_DIR_SRC => $CACHE_DIR_DST"
 		cache_mounts+=("$CACHE_DIR_SRC:$CACHE_DIR_DST")
 	fi
 
@@ -193,8 +193,7 @@ _zest_cache_volumes() {
 	if [[ ! -z $CACHE_DIR_SRCS && ! -z $CACHE_DIR_DSTS ]]; then
 		cache_dir_count=${#CACHE_DIR_SRCS[@]}
 		for ((i=0; i < $cache_dir_count; i++)); do
-			src=${CACHE_DIR_SRCS[$i]}
-			dst=${CACHE_DIR_DSTS[$i]}
+			src=${CACHE_DIR_SRCS[$i]} dst=${CACHE_DIR_DSTS[$i]}
 			# _debug "Including cache directory $src => $dst"
 			cache_mounts+=("$src:$dst")
 		done
@@ -215,13 +214,16 @@ _zest_build() {
 	# First ensure we're a service
 	_debug "Checking service ${SERVICE}"
 
-    SERVICEPATH=$(find . -type d -maxdepth 2 | grep ${SERVICE} | head -n 1)
-    if [[ "$SERVICEPATH" == "" ]]; then
-	 _debug "Service path is empty, setting to current path"
-       SERVICEPATH="."
+    SERVICE_PATH=$(find $(pwd) -type d -maxdepth 2 | grep ${SERVICE} | head -n 1)
+
+    if [[ "$SERVICE_PATH" == "" ]]; then
+	    _debug "Service path is empty, setting to current path"
+        SERVICE_PATH=$(pwd)
     fi
 
-	if ! _zest_is_service $SERVICEPATH ; then
+    _debug "service_path: ${SERVICE_PATH}"
+
+	if ! _zest_is_service $SERVICE_PATH ; then
 		_fatal "$SERVICE is not a service"
 	fi
 
@@ -254,8 +256,14 @@ _zest_build() {
 
 	# Build in the container
 	_info "Building service $SERVICE_NAME in $BUILD_CONTAINER"
+    # _debug "servicepath: $SERVICE_PATH"
+    # _debug "mountDir: $MOUNT_DIR"
+    # _debug "service: $SERVICE"
+    # _debug "build container: $BUILD_CONTAINER"
+    # _debug "zesterpath: $ZESTER_PATH"
+    # _debug "cachevolumes: $(_zest_cache_volumes)"
 
-	docker run --rm -v $(pwd):$MOUNT_DIR/$SERVICE -w $MOUNT_DIR/$SERVICE -v $ZESTER_PATH:/usr/bin/zester:ro $(_zest_cache_volumes) $BUILD_CONTAINER zester build --name $SERVICE_NAME
+	docker run --rm -v $SERVICE_PATH:$MOUNT_DIR/$SERVICE -w $MOUNT_DIR/$SERVICE -v $ZESTER_PATH:/usr/bin/zester:ro $(_zest_cache_volumes) $BUILD_CONTAINER zester build --name $SERVICE_NAME
 
 	if [[ $? -ne 0 ]]; then
 		_fatal "Build failed"
@@ -274,12 +282,21 @@ _zest_build() {
 
 _zest_bundle() {
 
-	# Get the service name (folder name)
-	SERVICE=$(basename `pwd`)
+    SERVICE="${SERVICE_ARG:-$(basename `pwd`)}"
 
 	# First ensure we're a service
-	_debug "Checking service"
-	if ! _zest_is_service . ; then
+	_debug "Checking service ${SERVICE}"
+
+    SERVICE_PATH=$(find $(pwd) -type d -maxdepth 2 | grep ${SERVICE} | head -n 1)
+
+    if [[ "$SERVICE_PATH" == "" ]]; then
+	    _debug "Service path is empty, setting to current path"
+        SERVICE_PATH=$(pwd)
+    fi
+
+    _debug "service_path: ${SERVICE_PATH}"
+
+	if ! _zest_is_service $SERVICE_PATH ; then
 		_fatal "$SERVICE is not a service"
 	fi
 
@@ -331,10 +348,12 @@ _zest_bundle() {
 
 	if [[ "$IMAGE_SERVER" == "" ]]; then
 		_debug "Not using image server"
-		docker build $BUILD_ARGS --build-arg REVISION=$REVISION_OVERRIDE -t $REPO/$SERVICE:$VERSION -t $REPO/$SERVICE:latest -f $DOCKERFILE .
+        _debug "-f $DOCKERFILE $SERVICE_PATH"
+		docker build $BUILD_ARGS --build-arg REVISION=$REVISION_OVERRIDE -t $REPO/$SERVICE:$VERSION -t $REPO/$SERVICE:latest -f $SERVICE_PATH/$DOCKERFILE $SERVICE_PATH
 	else
 		_debug "Using image server $IMAGE_SERVER"
-		docker build $BUILD_ARGS --build-arg REVISION=$REVISION_OVERRIDE -t $IMAGE_SERVER/$REPO/$SERVICE:$VERSION -t $IMAGE_SERVER/$REPO/$SERVICE:latest -f $DOCKERFILE .
+		docker build $BUILD_ARGS --build-arg REVISION=$REVISION_OVERRIDE -t $IMAGE_SERVER/$REPO/$SERVICE:$VERSION -t $IMAGE_SERVER/$REPO/$SERVICE:latest -f $SERVICE_PATH/$DOCKERFILE $SERVICE_PATH
+
 	fi
 
 	if [[ $? -ne 0 ]]; then
@@ -413,14 +432,24 @@ _zest_push() {
 
 _zest_test() {
 
-	# Get the service name (folder name)
-	SERVICE=$(basename `pwd`)
+    SERVICE="${SERVICE_ARG:-$(basename `pwd`)}"
 
 	# First ensure we're a service
-	_debug "Checking service"
-	if ! _zest_is_service . ; then
+	_debug "Checking service ${SERVICE}"
+
+    SERVICE_PATH=$(find $(pwd) -type d -maxdepth 2 | grep ${SERVICE} | head -n 1)
+
+    if [[ "$SERVICE_PATH" == "" ]]; then
+	    _debug "Service path is empty, setting to current path"
+        SERVICE_PATH=$(pwd)
+    fi
+
+    _debug "service_path: ${SERVICE_PATH}"
+
+	if ! _zest_is_service $SERVICE_PATH ; then
 		_fatal "$SERVICE is not a service"
 	fi
+
 
 	# Must have $TEST_CONTAINER or $BUILD_CONTAINER set
 	if [[ "$TEST_CONTAINER" == "" ]]; then
@@ -446,7 +475,7 @@ _zest_test() {
 
 	# Build in the container
 	_info "Testing service $SERVICE in $TEST_CONTAINER"
-	docker run --rm -v $(pwd):$MOUNT_DIR/$SERVICE -w $MOUNT_DIR/$SERVICE -v $ZESTER_PATH:/usr/bin/zester:ro $(_zest_cache_volumes) $TEST_CONTAINER zester test --name $SERVICE_NAME
+	docker run --rm -v $SERVICE_PATH:$MOUNT_DIR/$SERVICE -w $MOUNT_DIR/$SERVICE -v $ZESTER_PATH:/usr/bin/zester:ro $(_zest_cache_volumes) $TEST_CONTAINER zester test --name $SERVICE_NAME
 
 	if [[ $? -ne 0 ]]; then
 		_fatal "Test failed"
@@ -633,7 +662,7 @@ _zest_all() {
 		_debug "Checking $dir"
 		if _zest_is_service $dir; then
 			_info "Zesting $dir"
-			bash -c "$ABSOLUTE_PATH build -s $dir $GO_VERBOSE && $ABSOLUTE_PATH test $GO_VERBOSE && $ABSOLUTE_PATH bundle $GO_VERBOSE" || _fatal "Zest all failed"
+			bash -c "$ABSOLUTE_PATH build -s $dir $GO_VERBOSE && $ABSOLUTE_PATH test -s $dir $GO_VERBOSE && $ABSOLUTE_PATH bundle -s $dir $GO_VERBOSE" || _fatal "Zest all failed"
 		fi
 	done
 


### PR DESCRIPTION
This will allow you to build with `zest build --service SERVICEPATH`
instead of going into individual components and running zest in them